### PR TITLE
test: pass custom ReadableStream in PutObject Body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,25 @@ document.getElementById("form").addEventListener("submit", async (e) => {
   const response = await client.putObject({
     Bucket: import.meta.env.VITE_AWS_S3_BUCKET_NAME,
     Key: file.name,
-    Body: file.stream(),
+    Body: new ReadableStream({
+      pull(controller) {
+        let counter = 0;
+        const maxCount = 5;
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            if (counter < maxCount) {
+              const chunk = `Data chunk ${counter + 1}`;
+              controller.enqueue(chunk);
+              counter++;
+              resolve();
+            } else {
+              controller.close();
+              resolve();
+            }
+          }, 1000);
+        });
+      },
+    }),
   });
 
   console.log("Response", response);


### PR DESCRIPTION
Attempts to pass custom ReadableStream instead of `blob.stream()`
It returns the same `net::ERR_H2_OR_QUIC_REQUIRED` error.